### PR TITLE
Automation pack fixes

### DIFF
--- a/src/TeleStorage/TeleStorageGasConfig.cs
+++ b/src/TeleStorage/TeleStorageGasConfig.cs
@@ -29,7 +29,7 @@ namespace TeleStorage
                 id: Id,
                 width: 5,
                 height: 3,
-                anim: "gastele",
+                anim: "gasstorage_kanim",
                 hitpoints: BUILDINGS.HITPOINTS.TIER2,
                 construction_time: BUILDINGS.CONSTRUCTION_TIME_SECONDS.TIER4,
                 construction_mass: construction_mass,

--- a/src/TeleStorage/TeleStorageGasConfig.cs
+++ b/src/TeleStorage/TeleStorageGasConfig.cs
@@ -59,17 +59,17 @@ namespace TeleStorage
 
         public override void DoPostConfigurePreview(BuildingDef def, GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
         }
 
         public override void DoPostConfigureUnderConstruction(GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
         }
 
         public override void DoPostConfigureComplete(GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
             go.AddOrGet<LogicOperationalController>();
             go.AddOrGet<Operational>();
 

--- a/src/TeleStorage/TeleStorageLiquidConfig.cs
+++ b/src/TeleStorage/TeleStorageLiquidConfig.cs
@@ -29,7 +29,7 @@ namespace TeleStorage
                 id: Id,
                 width: 2,
                 height: 3,
-                anim: "liquidtele",
+                anim: "liquidreservoir_kanim",
                 hitpoints: BUILDINGS.HITPOINTS.TIER2,
                 construction_time: BUILDINGS.CONSTRUCTION_TIME_SECONDS.TIER4,
                 construction_mass: construction_mass,

--- a/src/TeleStorage/TeleStorageLiquidConfig.cs
+++ b/src/TeleStorage/TeleStorageLiquidConfig.cs
@@ -59,17 +59,17 @@ namespace TeleStorage
 
         public override void DoPostConfigurePreview(BuildingDef def, GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
         }
 
         public override void DoPostConfigureUnderConstruction(GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
         }
 
         public override void DoPostConfigureComplete(GameObject go)
         {
-            GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1);
+            GeneratedBuildings.RegisterSingleLogicInputPort(go);
             go.AddOrGet<LogicOperationalController>();
             go.AddOrGet<Operational>();
 

--- a/src/TeleStorage/TeleStoragePatches.cs
+++ b/src/TeleStorage/TeleStoragePatches.cs
@@ -38,7 +38,7 @@ namespace TeleStorage
                 GameObject ___storagePanel, GameObject ___selectedTarget,
                 ref Dictionary<string, GameObject> ___storageLabels)
             {
-                if (___selectedTarget.GetComponent<TeleStorage>() == null)
+                if (___selectedTarget == null || ___selectedTarget.GetComponent<TeleStorage>() == null)
                 {
                     return;
                 }


### PR DESCRIPTION
(This PR includes #2 and #4 from other contributors, as at least the kanim change was required to get the mod to load)

Banhi's Automation Pack release adds new logic components and capabilities, and specifically changes the method for adding a single logic input port, from:

`GeneratedBuildings.RegisterLogicPorts(go, LogicOperationalController.INPUT_PORTS_0_1)`

to 

`GeneratedBuildings.RegisterSingleLogicInputPort(go)`

I have not yet placed these in-game as I'm at work 😈 but the game no longer crashes on startup with the mod install. I will test it working in-game sometime today.
